### PR TITLE
Fix encoding for appended strings

### DIFF
--- a/G-Earth/src/main/java/gearth/protocol/HPacket.java
+++ b/G-Earth/src/main/java/gearth/protocol/HPacket.java
@@ -491,6 +491,7 @@ public class HPacket implements StringifyAble {
         return this;
     }
     public HPacket appendString(String s) {
+        s = new String(s.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
         return appendString(s, StandardCharsets.ISO_8859_1);
     }
 

--- a/G-Earth/src/main/java/gearth/protocol/HPacket.java
+++ b/G-Earth/src/main/java/gearth/protocol/HPacket.java
@@ -491,7 +491,6 @@ public class HPacket implements StringifyAble {
         return this;
     }
     public HPacket appendString(String s) {
-        s = new String(s.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
         return appendString(s, StandardCharsets.ISO_8859_1);
     }
 
@@ -516,7 +515,7 @@ public class HPacket implements StringifyAble {
             appendInt((Integer)o);
         }
         else if (o instanceof String) {
-            appendString((String)o);
+            appendString((String)o, StandardCharsets.UTF_8);
         }
         else if (o instanceof Boolean) {
             appendBoolean((Boolean) o);


### PR DESCRIPTION
If a packet is constructed using the expression form, PacketStringUtils will encode properly the string like this:
`String latin = new String(actualString.toString().getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);`

This does not happen if the packet is constructed using the Object... constructor,
and packets like this:

 `new HPacket(10, 2, 100000, "Dragón de Fuego Azul", 3).toExpression();`

 will show � instead of ó.
 Whereas:

 `new HPacket("{l}{h:10}{i:2}{i:100000}{s:\"Dragón de Fuego Azul\"}{i:3}").toExpression();`

 would display the string correctly.