### PR TITLE
Add PortChecker

### DIFF
--- a/G-Earth/src/main/java/gearth/protocol/HConnection.java
+++ b/G-Earth/src/main/java/gearth/protocol/HConnection.java
@@ -80,6 +80,8 @@ public class HConnection {
             }
         } catch (IOException e) {
             e.printStackTrace();
+            setState(HState.ABORTING);
+            setState(HState.NOT_CONNECTED);
         }
     }
 

--- a/G-Earth/src/main/java/gearth/protocol/portchecker/PortChecker.java
+++ b/G-Earth/src/main/java/gearth/protocol/portchecker/PortChecker.java
@@ -1,0 +1,38 @@
+package gearth.protocol.portchecker;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * This interface wraps the OS-dependant operation of checking if a specific port is used by any program.
+ * Some programs like McAfee TrueKey run on port 30000. This will hopefully save the user some time troubleshooting.
+ */
+public interface PortChecker {
+    /**
+     * @param port port to check
+     * @return process name or null if none
+     */
+    String getProcessUsingPort(int port) throws IOException;
+
+    /** Runs a command and reads the first line of output
+     * @param command Command to run
+     * @return {@link String} containing the output
+     * @throws IOException If an I/O error occurs
+     */
+    default String getCommandOutput(String[] command) throws IOException {
+        try {
+            Runtime rt = Runtime.getRuntime();
+            Process proc = rt.exec(command);
+
+            BufferedReader stdInput = new BufferedReader(new
+                    InputStreamReader(proc.getInputStream()));
+
+            return stdInput.readLine();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+}

--- a/G-Earth/src/main/java/gearth/protocol/portchecker/PortCheckerFactory.java
+++ b/G-Earth/src/main/java/gearth/protocol/portchecker/PortCheckerFactory.java
@@ -1,0 +1,20 @@
+package gearth.protocol.portchecker;
+
+import gearth.misc.OSValidator;
+import org.apache.commons.lang3.NotImplementedException;
+
+public final class PortCheckerFactory {
+    private PortCheckerFactory() {}
+
+    public static PortChecker getPortChecker() {
+        if (OSValidator.isWindows()) {
+            return new WindowsPortChecker();
+        }
+
+        if (OSValidator.isUnix()) {
+            return new UnixPortChecker();
+        }
+
+        throw new NotImplementedException("macOS port checker not implemented yet");
+    }
+}

--- a/G-Earth/src/main/java/gearth/protocol/portchecker/UnixPortChecker.java
+++ b/G-Earth/src/main/java/gearth/protocol/portchecker/UnixPortChecker.java
@@ -1,0 +1,13 @@
+package gearth.protocol.portchecker;
+
+import java.io.IOException;
+
+public class UnixPortChecker implements PortChecker {
+
+    @Override
+    public String getProcessUsingPort(int port) throws IOException {
+        String netstatOut = getCommandOutput(new String[] {"/bin/sh", "-c", " netstat -nlp | grep :" + port});
+        int index = netstatOut.lastIndexOf("LISTEN      ");
+        return netstatOut.substring(index + 12);
+    }
+}

--- a/G-Earth/src/main/java/gearth/protocol/portchecker/WindowsPortChecker.java
+++ b/G-Earth/src/main/java/gearth/protocol/portchecker/WindowsPortChecker.java
@@ -1,0 +1,25 @@
+package gearth.protocol.portchecker;
+
+import java.io.IOException;
+
+public class WindowsPortChecker implements PortChecker{
+    @Override
+    public String getProcessUsingPort(int port) throws IOException {
+        try {
+            String s = getCommandOutput(new String[] {"cmd", "/c", " netstat -ano | findstr LISTENING | findstr " + port});
+            int index = s.lastIndexOf(" ");
+            String pid = s.substring(index);
+
+            return getProcessNameFromPid(pid);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    private String getProcessNameFromPid(String pid) throws IOException {
+        String task = getCommandOutput(new String[] {"tasklist /fi \"pid eq " + pid + "\" /nh /fo:CSV"});
+        int index = task.indexOf(',');
+        return task.substring(0, index);
+    }
+}


### PR DESCRIPTION
This helps troubleshooting in case the proxy port is already being used by another program, where G-Earth silently fails.

## Steps to test this

### Linux
1. On a terminal run `nc -l 30000` to start a server listening on port 30000
2. Open G-Earth and click connect
3. Boom
![Screenshot from 2021-07-30 23-41-34](https://user-images.githubusercontent.com/6912584/127714382-cae0136c-08a9-4e67-9af8-3893326b726a.png)

### Windows
1. Start a server on port 30000. I tried nc with MobaXterm and it didn't work, so I ended up coding a simple one.
2. Open G-Earth and click connect
3. [Insert same screenshot but in Windows, it should work...]

### macOS
I don't have any macOS machine I can use right now, so it will just not work on mac by now.
