### PR TITLE
Fix nitro ssl certificate caching issue

### DIFF
--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
@@ -11,6 +11,8 @@ import gearth.protocol.connection.proxy.nitro.http.NitroHttpProxyServerCallback;
 import gearth.protocol.connection.proxy.nitro.websocket.NitroWebsocketProxy;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCallback, StateChangeListener {
 
@@ -21,6 +23,7 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
     private final NitroWebsocketProxy nitroWebsocketProxy;
 
     private String originalWebsocketUrl;
+    private String originalOriginUrl;
 
     public NitroProxyProvider(HProxySetter proxySetter, HStateSetter stateSetter, HConnection connection) {
         this.proxySetter = proxySetter;
@@ -32,6 +35,10 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
 
     public String getOriginalWebsocketUrl() {
         return originalWebsocketUrl;
+    }
+
+    public String getOriginalOriginUrl() {
+        return originalOriginUrl;
     }
 
     @Override
@@ -79,6 +86,8 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
     @Override
     public String replaceWebsocketServer(String configUrl, String websocketUrl) {
         originalWebsocketUrl = websocketUrl;
+        originalOriginUrl = extractOriginUrl(configUrl);
+
         return String.format("ws://127.0.0.1:%d", NitroConstants.WEBSOCKET_PORT);
     }
 
@@ -89,5 +98,16 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
             // We are not stopping the http proxy because some requests might still require it to be running.
             nitroHttpProxy.pause();
         }
+    }
+
+    private static String extractOriginUrl(String url) {
+        try {
+            final URI uri = new URI(url);
+            return String.format("%s://%s/", uri.getScheme(), uri.getHost());
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+
+        return null;
     }
 }

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroCertificateSniffingManager.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroCertificateSniffingManager.java
@@ -1,0 +1,94 @@
+package gearth.protocol.connection.proxy.nitro.http;
+
+import io.netty.handler.codec.http.HttpRequest;
+import org.littleshoot.proxy.MitmManager;
+import org.littleshoot.proxy.mitm.*;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+/**
+ * {@link MitmManager} that uses the common name and subject alternative names
+ * from the upstream certificate to create a dynamic certificate with it.
+ */
+public class NitroCertificateSniffingManager implements MitmManager {
+
+    private static final boolean DEBUG = false;
+
+    private BouncyCastleSslEngineSource sslEngineSource;
+
+    public NitroCertificateSniffingManager(Authority authority) throws RootCertificateException {
+        try {
+            sslEngineSource = new BouncyCastleSslEngineSource(authority, true, true);
+        } catch (final Exception e) {
+            throw new RootCertificateException("Errors during assembling root CA.", e);
+        }
+    }
+
+    public SSLEngine serverSslEngine(String peerHost, int peerPort) {
+        return sslEngineSource.newSslEngine(peerHost, peerPort);
+    }
+
+    public SSLEngine serverSslEngine() {
+        return sslEngineSource.newSslEngine();
+    }
+
+    public SSLEngine clientSslEngineFor(HttpRequest httpRequest, SSLSession serverSslSession) {
+        try {
+            X509Certificate upstreamCert = getCertificateFromSession(serverSslSession);
+            // TODO store the upstream cert by commonName to review it later
+
+            // A reasons to not use the common name and the alternative names
+            // from upstream certificate from serverSslSession to create the
+            // dynamic certificate:
+            //
+            // It's not necessary. The host name is accepted by the browser.
+            //
+            String commonName = getCommonName(upstreamCert);
+
+            SubjectAlternativeNameHolder san = new SubjectAlternativeNameHolder();
+
+            san.addAll(upstreamCert.getSubjectAlternativeNames());
+
+            if (DEBUG) {
+                System.out.printf("[NitroCertificateSniffingManager] Subject Alternative Names: %s%n", san);
+            }
+
+            return sslEngineSource.createCertForHost(commonName, san);
+        } catch (Exception e) {
+            throw new FakeCertificateException("Creation dynamic certificate failed", e);
+        }
+    }
+
+    private X509Certificate getCertificateFromSession(SSLSession sslSession) throws SSLPeerUnverifiedException {
+        Certificate[] peerCerts = sslSession.getPeerCertificates();
+        Certificate peerCert = peerCerts[0];
+        if (peerCert instanceof java.security.cert.X509Certificate) {
+            return (java.security.cert.X509Certificate) peerCert;
+        }
+        throw new IllegalStateException("Required java.security.cert.X509Certificate, found: " + peerCert);
+    }
+
+    private String getCommonName(X509Certificate c) {
+        if (DEBUG) {
+            System.out.printf("[NitroCertificateSniffingManager] Subject DN principal name: %s%n", c.getSubjectDN().getName());
+        }
+
+        for (String each : c.getSubjectDN().getName().split(",\\s*")) {
+            if (each.startsWith("CN=")) {
+                String result = each.substring(3);
+
+                if (DEBUG) {
+                    System.out.printf("[NitroCertificateSniffingManager] Common Name: %s%n", c.getSubjectDN().getName());
+                }
+
+                return result;
+            }
+        }
+
+        throw new IllegalStateException("Missed CN in Subject DN: " + c.getSubjectDN());
+    }
+}

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroCertificateSniffingManager.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroCertificateSniffingManager.java
@@ -9,6 +9,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 /**
  * {@link MitmManager} that uses the common name and subject alternative names
@@ -18,11 +19,11 @@ public class NitroCertificateSniffingManager implements MitmManager {
 
     private static final boolean DEBUG = false;
 
-    private BouncyCastleSslEngineSource sslEngineSource;
+    private final BouncyCastleSslEngineSource sslEngineSource;
 
     public NitroCertificateSniffingManager(Authority authority) throws RootCertificateException {
         try {
-            sslEngineSource = new BouncyCastleSslEngineSource(authority, true, true);
+            sslEngineSource = new BouncyCastleSslEngineSource(authority, true, true, null);
         } catch (final Exception e) {
             throw new RootCertificateException("Errors during assembling root CA.", e);
         }
@@ -54,7 +55,11 @@ public class NitroCertificateSniffingManager implements MitmManager {
             san.addAll(upstreamCert.getSubjectAlternativeNames());
 
             if (DEBUG) {
-                System.out.printf("[NitroCertificateSniffingManager] Subject Alternative Names: %s%n", san);
+                System.out.println("[NitroCertificateSniffingManager] Subject Alternative Names");
+
+                for (List<?> name : upstreamCert.getSubjectAlternativeNames()) {
+                    System.out.printf("[NitroCertificateSniffingManager] - %s%n", name.toString());
+                }
             }
 
             return sslEngineSource.createCertForHost(commonName, san);

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
@@ -95,7 +95,7 @@ public class NitroHttpProxy {
         try {
             proxyServer = DefaultHttpProxyServer.bootstrap()
                     .withPort(NitroConstants.HTTP_PORT)
-                    .withManInTheMiddle(new CertificateSniffingMitmManager(authority))
+                    .withManInTheMiddle(new NitroCertificateSniffingManager(authority))
                     .withFiltersSource(new NitroHttpProxyFilterSource(serverCallback))
                     .start();
 

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
@@ -10,7 +10,6 @@ import javafx.scene.control.ButtonType;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.littleshoot.proxy.mitm.Authority;
-import org.littleshoot.proxy.mitm.CertificateSniffingMitmManager;
 import org.littleshoot.proxy.mitm.RootCertificateException;
 
 import java.io.File;

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
@@ -54,7 +54,7 @@ public class NitroHttpProxy {
                     ButtonType.YES, ButtonType.NO
             );
 
-            shouldInstall.set(!(alert.showAndWait().filter(t -> t == ButtonType.YES).isPresent()));
+            shouldInstall.set(alert.showAndWait().filter(t -> t == ButtonType.YES).isPresent());
             waitForDialog.release();
         });
 

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/os/windows/NitroWindows.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/os/windows/NitroWindows.java
@@ -15,7 +15,7 @@ public class NitroWindows implements NitroOsFunctions {
     /**
      * Semicolon separated hosts to ignore for proxying.
      */
-    private static final String PROXY_IGNORE = "discord.com;github.com;";
+    private static final String PROXY_IGNORE = "discord.com;discordapp.com;github.com;";
 
     /**
      * Checks if the certificate is trusted by the local machine.

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
@@ -112,7 +112,7 @@ public class NitroWebsocketClient implements NitroSession {
 
             // Reset program state.
             proxySetter.setProxy(null);
-            stateSetter.setState(HState.NOT_CONNECTED);
+            stateSetter.setState(HState.ABORTING);
         }
     }
 }

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
@@ -39,7 +39,7 @@ public class NitroWebsocketClient implements NitroSession {
         activeSession = session;
         activeSession.setMaxBinaryMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
 
-        server.connect(proxyProvider.getOriginalWebsocketUrl());
+        server.connect(proxyProvider.getOriginalWebsocketUrl(), proxyProvider.getOriginalOriginUrl());
 
         final HProxy proxy = new HProxy(HClient.NITRO, "", "", -1, -1, "");
 


### PR DESCRIPTION
Sites with the same "common name", such as all cloudflare sites `sni.cloudflaressl.com` that use SNI, were all given the same certificate because of caching functionality in BouncyCastleSslEngineSource. 

https://github.com/ganskef/LittleProxy-mitm/blob/4238e7a2ee68e260e0caa33aac41021fdf1a7391/src/main/java/org/littleshoot/proxy/mitm/BouncyCastleSslEngineSource.java#L316-L326

This PR fixes that by disabling the cache, which is [safe according the developer](https://github.com/ganskef/LittleProxy-mitm/blob/4238e7a2ee68e260e0caa33aac41021fdf1a7391/src/main/java/org/littleshoot/proxy/mitm/BouncyCastleSslEngineSource.java#L96-L100).