### PR TITLE
Bugfix: Set G-Earth as owner of all alerts

### DIFF
--- a/G-Earth/src/main/java/gearth/GEarth.java
+++ b/G-Earth/src/main/java/gearth/GEarth.java
@@ -16,6 +16,7 @@ import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.Alert;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
@@ -165,5 +166,9 @@ public class GEarth extends Application {
 
     public static Theme getTheme() {
         return observableTheme.getObject();
+    }
+
+    public static void setAlertOwner(Alert alert) {
+        alert.initOwner(main.stage);
     }
 }

--- a/G-Earth/src/main/java/gearth/ui/titlebar/TitleBarController.java
+++ b/G-Earth/src/main/java/gearth/ui/titlebar/TitleBarController.java
@@ -49,6 +49,7 @@ public class TitleBarController {
     }
 
     public static TitleBarController create(Alert alert) throws IOException {
+        GEarth.setAlertOwner(alert);
 
         FXMLLoader loader = new FXMLLoader(TitleBarController.class.getResource("Titlebar.fxml"));
         Parent titleBar = loader.load();


### PR DESCRIPTION
Alerts appeared behind G-Earth when G-Earth's  "Always on top" option was enabled, this caused the alert to be unreachable and G-Earth to be unresponsive

Fix: Every alert now get's initialized with G-Earth's main stage as it's owner allowing it to always be on top of G-Earth