### PR TITLE
Add cloudflare cookies support for Nitro WebSocket connections

### DIFF
--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
@@ -1,6 +1,5 @@
 package gearth.protocol.connection.proxy.nitro.http;
 
-import gearth.GEarth;
 import gearth.misc.ConfirmationDialog;
 import gearth.protocol.connection.proxy.nitro.NitroConstants;
 import gearth.protocol.connection.proxy.nitro.os.NitroOsFunctions;
@@ -10,8 +9,6 @@ import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
-import javafx.scene.image.Image;
-import javafx.stage.Stage;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.littleshoot.proxy.mitm.Authority;

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyServerCallback.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyServerCallback.java
@@ -11,4 +11,9 @@ public interface NitroHttpProxyServerCallback {
      */
     String replaceWebsocketServer(String configUrl, String websocketUrl);
 
+    /**
+     * Sets the parsed cookies for the origin WebSocket connection.
+     */
+    void setOriginCookies(String cookieHeaderValue);
+
 }


### PR DESCRIPTION
This PR adds support for hotels with heavy cloudflare protection (the checking your browser page).
It works by grabbing the `Cookie` header from the `renderer-config.json` file with the normal HTTP proxy and saving the cookies for whenever the WebSocket connection is started.

It also adds more headers that would normally be sent to the origin WebSocket connection, in an attempt to seem more legit.