### PR TITLE
Randomize nitro websocket port

### DIFF
--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroConstants.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroConstants.java
@@ -5,7 +5,6 @@ public final class NitroConstants {
     public static final int HTTP_PORT = 9090;
     public static final int HTTP_BUFFER_SIZE = 1024 * 1024 * 10;
 
-    public static final int WEBSOCKET_PORT = 2096;
     public static final int WEBSOCKET_BUFFER_SIZE = 1024 * 1024 * 10;
     public static final String WEBSOCKET_REVISION = "PRODUCTION-201611291003-338511768";
     public static final String WEBSOCKET_CLIENT_IDENTIFIER = "HTML5";

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
@@ -24,6 +24,7 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
     private final NitroWebsocketProxy nitroWebsocketProxy;
     private final AtomicBoolean abortLock;
 
+    private int websocketPort;
     private String originalWebsocketUrl;
     private String originalCookies;
 
@@ -63,6 +64,8 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
             return;
         }
 
+        websocketPort = nitroWebsocketProxy.getPort();
+
         stateSetter.setState(HState.WAITING_FOR_CLIENT);
     }
 
@@ -101,7 +104,7 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
     public String replaceWebsocketServer(String configUrl, String websocketUrl) {
         originalWebsocketUrl = websocketUrl;
 
-        return String.format("ws://127.0.0.1:%d", NitroConstants.WEBSOCKET_PORT);
+        return String.format("ws://127.0.0.1:%d", websocketPort);
     }
 
     @Override

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
@@ -106,6 +106,7 @@ public class NitroHttpProxy {
                     .withPort(NitroConstants.HTTP_PORT)
                     .withManInTheMiddle(new NitroCertificateSniffingManager(authority))
                     .withFiltersSource(new NitroHttpProxyFilterSource(serverCallback))
+                    .withTransparent(true)
                     .start();
 
             if (!initializeCertificate()) {

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketProxy.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketProxy.java
@@ -3,10 +3,11 @@ package gearth.protocol.connection.proxy.nitro.websocket;
 import gearth.protocol.HConnection;
 import gearth.protocol.connection.HProxySetter;
 import gearth.protocol.connection.HStateSetter;
-import gearth.protocol.connection.proxy.nitro.NitroConstants;
 import gearth.protocol.connection.proxy.nitro.NitroProxyProvider;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
@@ -28,7 +29,7 @@ public class NitroWebsocketProxy {
         this.stateSetter = stateSetter;
         this.connection = connection;
         this.proxyProvider = proxyProvider;
-        this.server = new Server(NitroConstants.WEBSOCKET_PORT);
+        this.server = new Server(0);
     }
 
     public boolean start() {
@@ -54,6 +55,12 @@ public class NitroWebsocketProxy {
         }
         
         return false;
+    }
+
+    public int getPort() {
+        final ServerConnector serverConnector = (ServerConnector) server.getConnectors()[0];
+
+        return serverConnector.getLocalPort();
     }
 
     public void stop() {


### PR DESCRIPTION
Some hotels detect G-Earth by checking for a successful connection on `localhost:2096`.
This PR changes the port to be allocated by random.

About port conflicts
> That won't happen. According to the documentation I read, the random port is chosen by Java. Which internally uses the relevant OS apis to determine an random ephemeral port.