### PR TITLE
Implement basic logging using logback

### DIFF
--- a/G-Earth/pom.xml
+++ b/G-Earth/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <javafx.version>1.8</javafx.version>
         <jettyVersion>9.4.48.v20220622</jettyVersion>
+        <logback.version>1.3.5</logback.version>
     </properties>
 
     <parent>
@@ -224,11 +225,12 @@
             <groupId>com.github.tulskiy</groupId>
             <artifactId>jkeymaster</artifactId>
             <version>1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.0-alpha0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.maven/maven-artifact -->
         <dependency>
@@ -274,17 +276,32 @@
             <groupId>com.github.ganskef</groupId>
             <artifactId>littleproxy-mitm</artifactId>
             <version>1.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
-
-
-
         <dependency>
             <groupId>G-Earth</groupId>
             <artifactId>G-Wasm-Minimal</artifactId>
             <version>1.0.3</version>
         </dependency>
-
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/G-Earth/src/main/java/gearth/GEarth.java
+++ b/G-Earth/src/main/java/gearth/GEarth.java
@@ -48,7 +48,13 @@ public class GEarth extends Application {
         stage = primaryStage;
 
         FXMLLoader loader = new FXMLLoader(getClass().getResource("/gearth/ui/G-Earth.fxml"));
-        Parent root = loader.load();
+        Parent root;
+        try {
+            root = loader.load();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return;
+        }
         controller = loader.getController();
         controller.setStage(primaryStage);
         stage.initStyle(StageStyle.TRANSPARENT);

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroConstants.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroConstants.java
@@ -5,7 +5,6 @@ public final class NitroConstants {
     public static final int HTTP_PORT = 9090;
     public static final int HTTP_BUFFER_SIZE = 1024 * 1024 * 10;
 
-    public static final int WEBSOCKET_PORT = 2096;
     public static final int WEBSOCKET_BUFFER_SIZE = 1024 * 1024 * 10;
     public static final String WEBSOCKET_REVISION = "PRODUCTION-201611291003-338511768";
     public static final String WEBSOCKET_CLIENT_IDENTIFIER = "HTML5";

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
@@ -24,6 +24,7 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
     private final NitroWebsocketProxy nitroWebsocketProxy;
     private final AtomicBoolean abortLock;
 
+    private int websocketPort;
     private String originalWebsocketUrl;
     private String originalCookies;
 
@@ -63,6 +64,8 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
             return;
         }
 
+        websocketPort = nitroWebsocketProxy.getPort();
+
         stateSetter.setState(HState.WAITING_FOR_CLIENT);
     }
 
@@ -101,7 +104,7 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
     public String replaceWebsocketServer(String configUrl, String websocketUrl) {
         originalWebsocketUrl = websocketUrl;
 
-        return String.format("ws://127.0.0.1:%d", NitroConstants.WEBSOCKET_PORT);
+        return String.format("ws://127.0.0.1:%d", websocketPort);
     }
 
     @Override

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxy.java
@@ -106,6 +106,7 @@ public class NitroHttpProxy {
                     .withPort(NitroConstants.HTTP_PORT)
                     .withManInTheMiddle(new NitroCertificateSniffingManager(authority))
                     .withFiltersSource(new NitroHttpProxyFilterSource(serverCallback))
+                    .withTransparent(true)
                     .start();
 
             if (!initializeCertificate()) {

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
@@ -6,14 +6,13 @@ import gearth.protocol.connection.*;
 import gearth.protocol.connection.proxy.nitro.NitroConstants;
 import gearth.protocol.connection.proxy.nitro.NitroProxyProvider;
 import gearth.protocol.packethandler.nitro.NitroPacketHandler;
-import org.eclipse.jetty.websocket.common.WebSocketSession;
 import org.eclipse.jetty.websocket.jsr356.JsrSession;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.websocket.*;
 import javax.websocket.server.ServerEndpoint;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +21,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @ServerEndpoint(value = "/")
 public class NitroWebsocketClient implements NitroSession {
+
+    private static final Logger logger = LoggerFactory.getLogger(NitroWebsocketClient.class);
 
     private final HProxySetter proxySetter;
     private final HStateSetter stateSetter;
@@ -45,6 +46,8 @@ public class NitroWebsocketClient implements NitroSession {
 
     @OnOpen
     public void onOpen(Session session) throws Exception {
+        logger.info("WebSocket connection accepted");
+
         activeSession = (JsrSession) session;
         activeSession.setMaxBinaryMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
 

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketProxy.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketProxy.java
@@ -3,10 +3,11 @@ package gearth.protocol.connection.proxy.nitro.websocket;
 import gearth.protocol.HConnection;
 import gearth.protocol.connection.HProxySetter;
 import gearth.protocol.connection.HStateSetter;
-import gearth.protocol.connection.proxy.nitro.NitroConstants;
 import gearth.protocol.connection.proxy.nitro.NitroProxyProvider;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
@@ -28,7 +29,7 @@ public class NitroWebsocketProxy {
         this.stateSetter = stateSetter;
         this.connection = connection;
         this.proxyProvider = proxyProvider;
-        this.server = new Server(NitroConstants.WEBSOCKET_PORT);
+        this.server = new Server(0);
     }
 
     public boolean start() {
@@ -54,6 +55,12 @@ public class NitroWebsocketProxy {
         }
         
         return false;
+    }
+
+    public int getPort() {
+        final ServerConnector serverConnector = (ServerConnector) server.getConnectors()[0];
+
+        return serverConnector.getLocalPort();
     }
 
     public void stop() {

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketServer.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketServer.java
@@ -6,8 +6,9 @@ import gearth.protocol.connection.proxy.nitro.NitroConstants;
 import gearth.protocol.packethandler.PacketHandler;
 import gearth.protocol.packethandler.nitro.NitroPacketHandler;
 import org.eclipse.jetty.websocket.api.extensions.ExtensionConfig;
-import org.eclipse.jetty.websocket.common.extensions.compress.PerMessageDeflateExtension;
 import org.eclipse.jetty.websocket.jsr356.JsrExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.websocket.*;
 import java.io.IOException;
@@ -15,6 +16,8 @@ import java.net.URI;
 import java.util.*;
 
 public class NitroWebsocketServer extends Endpoint implements NitroSession {
+
+    private static final Logger logger = LoggerFactory.getLogger(NitroWebsocketServer.class);
 
     private static final HashSet<String> SKIP_HEADERS = new HashSet<>(Arrays.asList(
             "Sec-WebSocket-Extensions",
@@ -36,6 +39,8 @@ public class NitroWebsocketServer extends Endpoint implements NitroSession {
 
     public void connect(String websocketUrl, Map<String, List<String>> clientHeaders) throws IOException {
         try {
+            logger.info("Connecting to origin websocket at {}", websocketUrl);
+
             ClientEndpointConfig.Builder builder = ClientEndpointConfig.Builder.create();
 
             builder.extensions(Collections.singletonList(new JsrExtension(new ExtensionConfig("permessage-deflate;client_max_window_bits"))));
@@ -57,6 +62,8 @@ public class NitroWebsocketServer extends Endpoint implements NitroSession {
             ClientEndpointConfig config = builder.build();
 
             ContainerProvider.getWebSocketContainer().connectToServer(this, config, URI.create(websocketUrl));
+
+            logger.info("Connected to origin websocket");
         } catch (DeploymentException e) {
             throw new IOException("Failed to deploy websocket client", e);
         }

--- a/G-Earth/src/main/resources/logback.xml
+++ b/G-Earth/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="com.tulskiy.keymaster" level="WARN"/>
+    <logger name="io.netty" level="WARN"/>
+    <logger name="org.littleshoot" level="OFF"/>
+    <logger name="org.eclipse.jetty" level="WARN"/>
+</configuration>


### PR DESCRIPTION
⚠️ This PR should be merged after https://github.com/sirjonasxx/G-Earth/pull/143 is merged.

This PR introduces a "getting started" for getting logging integrated into G-Earth.
When working on G-Earth or requesting information from users, it would be very useful if there is a log available with precise information on what happened.

My intent is to get this PR merged ASAP so G-Earth developers can start using
```java
private static final Logger logger = LoggerFactory.getLogger(<class>.class);
```
to passively add proper logging to any new and/or old code.

> In the pom.xml, some dependencies have the `slf4j-api` dependency excluded because they reference an older version. The `logback-classic` dependency introduces the `slf4j-api` version `2.0.4`. So this is done to prevent conflicts.

> `logback-classic` dependency is targeting a slightly older version (`1.3.5`) because the later versions require an higher Java version. Since G-Earth is stuck on Java 8 at this moment we can't bump the version.