### PR TITLE
Disable SSL certificate validation for Nitro websocket connection

### DIFF
--- a/G-Earth/pom.xml
+++ b/G-Earth/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <javafx.version>1.8</javafx.version>
-        <jettyVersion>9.4.48.v20220622</jettyVersion>
+        <jettyVersion>9.4.50.v20221201</jettyVersion>
         <logback.version>1.3.5</logback.version>
     </properties>
 
@@ -238,14 +238,11 @@
             <artifactId>maven-artifact</artifactId>
             <version>3.6.3</version>
         </dependency>
-
-
         <dependency>
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
             <version>1.1</version>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroSession.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroSession.java
@@ -1,6 +1,6 @@
 package gearth.protocol.connection.proxy.nitro.websocket;
 
-import javax.websocket.Session;
+import org.eclipse.jetty.websocket.api.Session;
 
 public interface NitroSession {
 

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
@@ -50,6 +50,7 @@ public class NitroWebsocketClient implements NitroSession {
 
         activeSession = (JsrSession) session;
         activeSession.setMaxBinaryMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
+        activeSession.setMaxTextMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
 
         // Set proper headers to spoof being a real client.
         final Map<String, List<String>> headers = new HashMap<>(activeSession.getUpgradeRequest().getHeaders());
@@ -94,7 +95,7 @@ public class NitroWebsocketClient implements NitroSession {
     }
 
     @Override
-    public Session getSession() {
+    public org.eclipse.jetty.websocket.api.Session getSession() {
         return activeSession;
     }
 

--- a/G-Earth/src/main/java/gearth/protocol/packethandler/nitro/NitroPacketHandler.java
+++ b/G-Earth/src/main/java/gearth/protocol/packethandler/nitro/NitroPacketHandler.java
@@ -6,12 +6,16 @@ import gearth.protocol.connection.proxy.nitro.websocket.NitroSession;
 import gearth.protocol.packethandler.PacketHandler;
 import gearth.protocol.packethandler.PayloadBuffer;
 import gearth.services.extension_handler.ExtensionHandler;
+import org.eclipse.jetty.websocket.api.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import javax.websocket.Session;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public class NitroPacketHandler extends PacketHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(NitroPacketHandler.class);
 
     private final HMessage.Direction direction;
     private final NitroSession session;
@@ -39,7 +43,13 @@ public class NitroPacketHandler extends PacketHandler {
             buffer = buffer.clone();
         }
 
-        localSession.getAsyncRemote().sendBinary(ByteBuffer.wrap(buffer));
+        try {
+            localSession.getRemote().sendBytes(ByteBuffer.wrap(buffer));
+        } catch (IOException e) {
+            logger.error("Error sending packet to nitro client", e);
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Fixes the following exception:
> sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target

This pull request disables SSL certificate validation for Nitro Websocket connections.
I also rewrote the `G-Earth <-> Hotel` connection to use jetty websockets instead of javax websockets.

This pull request might also fix #148.