### PR TITLE
Fixed more typos in the MacOS installation guide

### DIFF
--- a/docs/wiki/macOs-Installation-guide.md
+++ b/docs/wiki/macOs-Installation-guide.md
@@ -31,7 +31,7 @@ There is a few steps u have to complete in order to get it to work on MacOS.
 ### Signing of G-Mem
 1. Open `Terminal` (press `⌘ + Enter`, type `Terminal` to open it from spotlight)
 2. Type `codesign -fs "gmem-cert" ` (do not press enter yet)
-3. Drag the `G-Mem` file into your terminal window (this will append the path to the file)
+3. Drag the `G-Mem` file into your terminal window *(this will append the path to the terminal)*
 
 Your terminal window should now resemble the following:
 
@@ -42,13 +42,13 @@ Your terminal window should now resemble the following:
 ### Making G-Mem executable
 1. Open `Terminal` (press `⌘ + Enter`, type `Terminal` to open it from spotlight)
 2. Type `chmod 755 ` (do not press enter yet)
-3. Drag the `G-Mem` file into your terminal window (this will append the path to the file)
+3. Drag the `G-Mem` file into your terminal window *(this will append the path to the terminal)*
 
 Your terminal window should now resemble the following:
 
 ![Screenshot 2023-03-30 at 14 52 29](https://user-images.githubusercontent.com/102377087/228841918-3205014b-5de8-431d-ae4d-d10b8ceeed03.png)
 
-4. Now press enter and verify the `Kind` of the `G-Mem` file is not `Unix Executable File`
+4. Now press enter and verify the `Kind` of the `G-Mem` file is now `Unix Executable File`
 
 ![Screenshot 2023-03-30 at 14 54 15](https://user-images.githubusercontent.com/102377087/228842389-78ea857e-3414-43d0-8270-91f8185ab57f.png)
 
@@ -67,7 +67,7 @@ A guide for disabling SIP can be found here: https://developer.apple.com/documen
 ## Launching G-Earth
 1. Open `Terminal` (press `⌘ + Enter`, type `Terminal` to open it from spotlight)
 2. Type `sudo java -jar `
-3. Drag the `G-Earth.jar` file into your terminal window (this will append the path to the file)
+3. Drag the `G-Earth.jar` file into your terminal window *(this will append the path to the terminal)*
 
 Your terminal window should now resemble the following:
 

--- a/docs/wiki/macOs-Installation-guide.md
+++ b/docs/wiki/macOs-Installation-guide.md
@@ -77,6 +77,12 @@ Your terminal window should now resemble the following:
 
 ## Troubleshooting
 
+### 🚫 Apple can’t check app for malicious software
+In this case, you can grant an exception for a blocked app by clicking the `Open Anyway` button in Privacy & Security settings. 
+This button is available for about an hour after you try to open the app. Where it appears exactly depends on the OS version u are running,
+more details about it can be found here: https://support.apple.com/en-gb/guide/mac-help/mchleab3a043/mac
+
+### Other
 If you experience any other issues and the [Troubleshooting Page](https://github.com/sirjonasxx/G-Earth/wiki/Troubleshooting) doesn't help, 
 
 it might be useful to have a look at the following issues: [#67](../issues/67) [#10](../issues/10)


### PR DESCRIPTION
- fixed typos
- added troubleshooting step