### PR TITLE
Improve Nitro reliability and bypass cloudflare challenge on french retro

### DIFF
--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroConnectionState.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroConnectionState.java
@@ -30,16 +30,24 @@ public class NitroConnectionState {
         this.checkConnected();
     }
 
-    public void checkConnected() {
+    public boolean isConnected() {
         if (this.aborting) {
-            return;
+            return false;
         }
 
         if (!this.toClient) {
-            return;
+            return false;
         }
 
         if (!this.toServer) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private void checkConnected() {
+        if (!this.isConnected()) {
             return;
         }
 

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroConnectionState.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroConnectionState.java
@@ -1,0 +1,58 @@
+package gearth.protocol.connection.proxy.nitro;
+
+import gearth.protocol.HMessage;
+import gearth.protocol.connection.HState;
+import gearth.protocol.connection.HStateSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NitroConnectionState {
+
+    private static final Logger logger = LoggerFactory.getLogger(NitroConnectionState.class);
+
+    private final HStateSetter stateSetter;
+
+    private boolean aborting;
+    private boolean toServer;
+    private boolean toClient;
+
+    public NitroConnectionState(HStateSetter stateSetter) {
+        this.stateSetter = stateSetter;
+    }
+
+    public void setConnected(HMessage.Direction direction) {
+        if (direction == HMessage.Direction.TOCLIENT) {
+            this.toClient = true;
+        } else if (direction == HMessage.Direction.TOSERVER) {
+            this.toServer = true;
+        }
+
+        this.checkConnected();
+    }
+
+    public void checkConnected() {
+        if (this.aborting) {
+            return;
+        }
+
+        if (!this.toClient) {
+            return;
+        }
+
+        if (!this.toServer) {
+            return;
+        }
+
+        this.stateSetter.setState(HState.CONNECTED);
+
+        logger.info("Connected");
+    }
+
+    public void setAborting() {
+        this.aborting = true;
+        this.stateSetter.setState(HState.ABORTING);
+
+        logger.info("Aborting");
+    }
+
+}

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroPacketQueue.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroPacketQueue.java
@@ -1,0 +1,28 @@
+package gearth.protocol.connection.proxy.nitro;
+
+import gearth.protocol.packethandler.nitro.NitroPacketHandler;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class NitroPacketQueue {
+
+    private final NitroPacketHandler packetHandler;
+    private final Queue<byte[]> packets;
+
+    public NitroPacketQueue(NitroPacketHandler packetHandler) {
+        this.packetHandler = packetHandler;
+        this.packets = new LinkedList<>();
+    }
+
+    public void enqueue(byte[] b) {
+        this.packets.add(b);
+    }
+
+    public synchronized void flush() throws IOException {
+        while (!this.packets.isEmpty()) {
+            this.packetHandler.act(this.packets.remove());
+        }
+    }
+}

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
@@ -2,9 +2,11 @@ package gearth.protocol.connection.proxy.nitro.websocket;
 
 import gearth.protocol.HConnection;
 import gearth.protocol.HMessage;
+import gearth.protocol.StateChangeListener;
 import gearth.protocol.connection.*;
 import gearth.protocol.connection.proxy.nitro.NitroConnectionState;
 import gearth.protocol.connection.proxy.nitro.NitroConstants;
+import gearth.protocol.connection.proxy.nitro.NitroPacketQueue;
 import gearth.protocol.connection.proxy.nitro.NitroProxyProvider;
 import gearth.protocol.packethandler.nitro.NitroPacketHandler;
 import org.eclipse.jetty.websocket.jsr356.JsrSession;
@@ -26,26 +28,48 @@ public class NitroWebsocketClient implements NitroSession {
     private static final Logger logger = LoggerFactory.getLogger(NitroWebsocketClient.class);
 
     private final HProxySetter proxySetter;
+    private final HConnection connection;
     private final NitroConnectionState state;
     private final NitroProxyProvider proxyProvider;
     private final NitroWebsocketServer server;
     private final NitroPacketHandler packetHandler;
+    private final NitroPacketQueue packetQueue;
     private final AtomicBoolean shutdownLock;
 
     private JsrSession activeSession = null;
 
     public NitroWebsocketClient(HProxySetter proxySetter, HStateSetter stateSetter, HConnection connection, NitroProxyProvider proxyProvider) {
         this.proxySetter = proxySetter;
+        this.connection = connection;
         this.state = new NitroConnectionState(stateSetter);
         this.proxyProvider = proxyProvider;
         this.server = new NitroWebsocketServer(connection, this, this.state);
         this.packetHandler = new NitroPacketHandler(HMessage.Direction.TOSERVER, server, connection.getExtensionHandler(), connection.getTrafficObservables());
+        this.packetQueue = new NitroPacketQueue(this.packetHandler);
         this.shutdownLock = new AtomicBoolean();
     }
 
     @OnOpen
     public void onOpen(Session session) throws Exception {
         logger.info("WebSocket connection accepted");
+
+        // Setup state change listener
+        connection.getStateObservable().addListener(new StateChangeListener() {
+            @Override
+            public void stateChanged(HState oldState, HState newState) {
+                // Clean up when we don't need it anymore.
+                if ((oldState == HState.WAITING_FOR_CLIENT || newState == HState.NOT_CONNECTED) || newState == HState.ABORTING) {
+                    connection.getStateObservable().removeListener(this);
+                }
+
+                // Process queue when connected.
+                try {
+                    packetQueue.flush();
+                } catch (IOException e) {
+                    logger.error("Failed to flush packet queue in state change listener", e);
+                }
+            }
+        });
 
         activeSession = (JsrSession) session;
         activeSession.setMaxBinaryMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
@@ -78,7 +102,14 @@ public class NitroWebsocketClient implements NitroSession {
     public void onMessage(byte[] b, Session session) throws IOException {
         logger.debug("Received packet from browser");
 
-        packetHandler.act(b);
+        // Enqueue all packets we receive to ensure we preserve correct packet order.
+        packetQueue.enqueue(b);
+
+        // Flush everything if we are connected.
+        // We also flush when connection state changes to connected.
+        if (state.isConnected()) {
+            packetQueue.flush();
+        }
     }
 
     @OnClose

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketServer.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketServer.java
@@ -2,6 +2,7 @@ package gearth.protocol.connection.proxy.nitro.websocket;
 
 import gearth.protocol.HConnection;
 import gearth.protocol.HMessage;
+import gearth.protocol.connection.proxy.nitro.NitroConnectionState;
 import gearth.protocol.connection.proxy.nitro.NitroConstants;
 import gearth.protocol.packethandler.PacketHandler;
 import gearth.protocol.packethandler.nitro.NitroPacketHandler;
@@ -47,10 +48,12 @@ public class NitroWebsocketServer implements WebSocketListener, NitroSession {
 
     private final PacketHandler packetHandler;
     private final NitroWebsocketClient client;
+    private final NitroConnectionState state;
     private Session activeSession = null;
 
-    public NitroWebsocketServer(HConnection connection, NitroWebsocketClient client) {
+    public NitroWebsocketServer(HConnection connection, NitroWebsocketClient client, NitroConnectionState state) {
         this.client = client;
+        this.state = state;
         this.packetHandler = new NitroPacketHandler(HMessage.Direction.TOCLIENT, client, connection.getExtensionHandler(), connection.getTrafficObservables());
     }
 
@@ -83,8 +86,6 @@ public class NitroWebsocketServer implements WebSocketListener, NitroSession {
 
             client.start();
             client.connect(this, URI.create(websocketUrl), request);
-
-            logger.info("Connected to origin websocket");
         } catch (Exception e) {
             throw new IOException("Failed to start websocket client to origin " + websocketUrl, e);
         }
@@ -139,6 +140,7 @@ public class NitroWebsocketServer implements WebSocketListener, NitroSession {
     @Override
     public void onWebSocketConnect(org.eclipse.jetty.websocket.api.Session session) {
         activeSession = session;
+        state.setConnected(HMessage.Direction.TOCLIENT);
     }
 
     @Override

--- a/G-Earth/src/main/java/gearth/protocol/packethandler/nitro/NitroPacketHandler.java
+++ b/G-Earth/src/main/java/gearth/protocol/packethandler/nitro/NitroPacketHandler.java
@@ -35,6 +35,7 @@ public class NitroPacketHandler extends PacketHandler {
         final Session localSession = session.getSession();
 
         if (localSession == null) {
+            logger.warn("Discarding {} bytes because the session for direction {} was null", buffer.length, this.direction);
             return false;
         }
 


### PR DESCRIPTION
We were sending duplicate headers, one being the default Jetty `User-Agent` header.
I have also improved reliability by queueing packets till the mitm connection is fully set up, otherwise packets would get discarded before the connection was ready.