### PR TITLE
Set correct maximum on websocket policy

### DIFF
--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketClient.java
@@ -72,8 +72,8 @@ public class NitroWebsocketClient implements NitroSession {
         });
 
         activeSession = (JsrSession) session;
-        activeSession.setMaxBinaryMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
-        activeSession.setMaxTextMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
+        activeSession.getPolicy().setMaxBinaryMessageSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
+        activeSession.getPolicy().setMaxTextMessageSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
 
         // Set proper headers to spoof being a real client.
         final Map<String, List<String>> headers = new HashMap<>(activeSession.getUpgradeRequest().getHeaders());

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketServer.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/websocket/NitroWebsocketServer.java
@@ -188,8 +188,8 @@ public class NitroWebsocketServer implements WebSocketListener, NitroSession {
     private WebSocketClient createWebSocketClient() {
         final WebSocketClient client = new WebSocketClient(createHttpClient());
 
-        client.setMaxBinaryMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
-        client.setMaxTextMessageBufferSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
+        client.getPolicy().setMaxBinaryMessageSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
+        client.getPolicy().setMaxTextMessageSize(NitroConstants.WEBSOCKET_BUFFER_SIZE);
 
         return client;
     }


### PR DESCRIPTION
I did an oopsie, but now it's fixed. No more disconnects because of packet sizes.