### PR TITLE
Improve Nitro socket url matching

### DIFF
--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
@@ -126,7 +126,7 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
     public String replaceWebsocketServer(String configUrl, String websocketUrl) {
         originalWebsocketUrl = websocketUrl;
 
-        return String.format("ws://127.0.0.1:%d", websocketPort);
+        return String.format("wss://127.0.0.1:%d", websocketPort);
     }
 
     @Override

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/NitroProxyProvider.java
@@ -6,6 +6,8 @@ import gearth.protocol.connection.HProxySetter;
 import gearth.protocol.connection.HState;
 import gearth.protocol.connection.HStateSetter;
 import gearth.protocol.connection.proxy.ProxyProvider;
+import gearth.protocol.connection.proxy.nitro.http.NitroAuthority;
+import gearth.protocol.connection.proxy.nitro.http.NitroCertificateSniffingManager;
 import gearth.protocol.connection.proxy.nitro.http.NitroHttpProxy;
 import gearth.protocol.connection.proxy.nitro.http.NitroHttpProxyServerCallback;
 import gearth.protocol.connection.proxy.nitro.websocket.NitroWebsocketProxy;
@@ -13,7 +15,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCallback, StateChangeListener {
@@ -32,11 +33,14 @@ public class NitroProxyProvider implements ProxyProvider, NitroHttpProxyServerCa
     private String originalCookies;
 
     public NitroProxyProvider(HProxySetter proxySetter, HStateSetter stateSetter, HConnection connection) {
+        final NitroAuthority authority = new NitroAuthority();
+        final NitroCertificateSniffingManager certificateManager = new NitroCertificateSniffingManager(authority);
+
         this.proxySetter = proxySetter;
         this.stateSetter = stateSetter;
         this.connection = connection;
-        this.nitroHttpProxy = new NitroHttpProxy(this);
-        this.nitroWebsocketProxy = new NitroWebsocketProxy(proxySetter, stateSetter, connection, this);
+        this.nitroHttpProxy = new NitroHttpProxy(this, certificateManager);
+        this.nitroWebsocketProxy = new NitroWebsocketProxy(proxySetter, stateSetter, connection, this, certificateManager);
         this.abortLock = new AtomicBoolean();
     }
 

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyFilter.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyFilter.java
@@ -16,9 +16,9 @@ import java.util.regex.Pattern;
 
 public class NitroHttpProxyFilter extends HttpFiltersAdapter {
 
-    private static final String NitroConfigSearch = "\"socket.url\"";
+    private static final String NitroConfigSearch = "socket.url";
     private static final String NitroClientSearch = "configurationUrls:";
-    private static final Pattern NitroConfigPattern = Pattern.compile("\"socket\\.url\":.?\"(wss?://.*?)\"", Pattern.MULTILINE);
+    private static final Pattern NitroConfigPattern = Pattern.compile("[\"']socket\\.url[\"']:.?[\"'](wss?://.*?)[\"']", Pattern.MULTILINE);
 
     // https://developers.cloudflare.com/fundamentals/get-started/reference/cloudflare-cookies/
     private static final HashSet<String> CloudflareCookies = new HashSet<>(Arrays.asList(

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyFilter.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyFilter.java
@@ -24,11 +24,16 @@ public class NitroHttpProxyFilter extends HttpFiltersAdapter {
     private static final HashSet<String> CloudflareCookies = new HashSet<>(Arrays.asList(
             "__cflb",
             "__cf_bm",
+            "__cfseq",
             "cf_ob_info",
             "cf_use_ob",
             "__cfwaitingroom",
             "__cfruid",
-            "cf_clearance"
+            "_cfuvid",
+            "cf_clearance",
+            "cf_chl_rc_i",
+            "cf_chl_rc_ni",
+            "cf_chl_rc_m"
     ));
 
     private static final String HeaderAcceptEncoding = "Accept-Encoding";

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyFilter.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyFilter.java
@@ -18,7 +18,7 @@ public class NitroHttpProxyFilter extends HttpFiltersAdapter {
 
     private static final String NitroConfigSearch = "socket.url";
     private static final String NitroClientSearch = "configurationUrls:";
-    private static final Pattern NitroConfigPattern = Pattern.compile("[\"']socket\\.url[\"']:.?[\"'](wss?://.*?)[\"']", Pattern.MULTILINE);
+    private static final Pattern NitroConfigPattern = Pattern.compile("[\"']socket\\.url[\"']:.+[\"'](wss?://.*?)[\"']", Pattern.MULTILINE);
 
     // https://developers.cloudflare.com/fundamentals/get-started/reference/cloudflare-cookies/
     private static final HashSet<String> CloudflareCookies = new HashSet<>(Arrays.asList(

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyFilter.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroHttpProxyFilter.java
@@ -18,7 +18,7 @@ public class NitroHttpProxyFilter extends HttpFiltersAdapter {
 
     private static final String NitroConfigSearch = "socket.url";
     private static final String NitroClientSearch = "configurationUrls:";
-    private static final Pattern NitroConfigPattern = Pattern.compile("[\"']socket\\.url[\"']:.+[\"'](wss?://.*?)[\"']", Pattern.MULTILINE);
+    private static final Pattern NitroConfigPattern = Pattern.compile("[\"']socket\\.url[\"']:(\\s+)?[\"'](wss?:.*?)[\"']", Pattern.MULTILINE);
 
     // https://developers.cloudflare.com/fundamentals/get-started/reference/cloudflare-cookies/
     private static final HashSet<String> CloudflareCookies = new HashSet<>(Arrays.asList(
@@ -95,11 +95,11 @@ public class NitroHttpProxyFilter extends HttpFiltersAdapter {
                 final Matcher matcher = NitroConfigPattern.matcher(responseBody);
 
                 if (matcher.find()) {
-                    final String originalWebsocket = matcher.group(1);
+                    final String originalWebsocket = matcher.group(2).replace("\\/", "/");
                     final String replacementWebsocket = callback.replaceWebsocketServer(this.url, originalWebsocket);
 
                     if (replacementWebsocket != null) {
-                        responseBody = responseBody.replace(originalWebsocket, replacementWebsocket);
+                        responseBody = responseBody.replace(matcher.group(2), replacementWebsocket);
                         responseModified = true;
                     }
                 }

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroSslContextFactory.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/http/NitroSslContextFactory.java
@@ -1,0 +1,20 @@
+package gearth.protocol.connection.proxy.nitro.http;
+
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import javax.net.ssl.SSLEngine;
+
+public class NitroSslContextFactory extends SslContextFactory.Server {
+
+    private final NitroCertificateSniffingManager certificateManager;
+
+    public NitroSslContextFactory(NitroCertificateSniffingManager certificateManager) {
+        this.certificateManager = certificateManager;
+    }
+
+    @Override
+    public SSLEngine newSSLEngine(String host, int port) {
+        System.out.printf("[NitroSslContextFactory] Creating SSLEngine for %s:%d%n", host, port);
+        return certificateManager.websocketSslEngine(host);
+    }
+}

--- a/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/os/windows/NitroWindows.java
+++ b/G-Earth/src/main/java/gearth/protocol/connection/proxy/nitro/os/windows/NitroWindows.java
@@ -15,7 +15,8 @@ public class NitroWindows implements NitroOsFunctions {
     /**
      * Semicolon separated hosts to ignore for proxying.
      */
-    private static final String PROXY_IGNORE = "discord.com;discordapp.com;github.com;";
+    // habba.io;
+    private static final String PROXY_IGNORE = "discord.com;discordapp.com;github.com;challenges.cloudflare.com;";
 
     /**
      * Checks if the certificate is trusted by the local machine.


### PR DESCRIPTION
Some hotels set their socket url in the javascript code in the html client.
These changes allow the filter to replace them as well.